### PR TITLE
Created GA to trigger code from calibration-supervisor

### DIFF
--- a/.github/workflows/triggering_code.yml
+++ b/.github/workflows/triggering_code.yml
@@ -1,0 +1,29 @@
+name: triggering_code
+
+on: 
+   push:  
+        paths:
+            - 'cameraSupervision/**'
+
+jobs:
+    test:
+      runs-on: [ubuntu-latest]
+      steps:
+        - name: Get Token
+          id: get_workflow_token
+          uses: tibdex/github-app-token@v1
+          with:
+            private_key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+            app_id: ${{ secrets.APPLICATION_ID }}
+            repository: icub-tech-iit/code
+            
+        - name: Repository dispatch to code
+          uses: peter-evans/repository-dispatch@v1
+          env:
+            GITHUB_APPS_TOKEN: ${{ steps.get_workflow_token.outputs.token }}
+          with:
+            token: ${{ env.GITHUB_APPS_TOKEN }}
+            repository: icub-tech-iit/code
+            event-type: repository_trigger
+            client-payload: '{"type": "repository_trigger", "img_list": "supervise-calib"}'
+


### PR DESCRIPTION
In this PR we created a GitHub Action which contains the following steps:

- the first one gets the token generated from the GitHub App
- the second one sends a repository dispatch to `code `with a `client_payload `containing the image to build