### PR TITLE
Fix camera supervision

### DIFF
--- a/cameraSupervision/app/run-all.sh
+++ b/cameraSupervision/app/run-all.sh
@@ -310,6 +310,7 @@ copyParams $icubEyesFile icubEyesElements outputElements
 
 #clean up files
 sed -i '$ d' $outputFile
+rm tmp.txt
 #sed -i '$ d' $icubEyesFile
 #sed -i '' -e '$ d' $outputFile
 

--- a/cameraSupervision/app/run-all.sh
+++ b/cameraSupervision/app/run-all.sh
@@ -31,7 +31,7 @@ function copyParams () {
                             then
                                 echo "Copying ${outputElem[$k,$j]} in section $group_name_icubeyes" 
                                 sed "${c}s/.*/${outputElem[$k,$j]}/" $icubEyesFile  > tmp.txt
-                                mv tmp.txt $icubEyesFile
+                                cp tmp.txt $icubEyesFile
                             fi
                         done
                     fi


### PR DESCRIPTION
With this PR we replaced the `mv` function with a `cp` because the copy of the `outputCalib.ini` into `customEyes.ini` was raising this error _mv: inter-device move failed: 'tmp.txt' to '/usr/local/share/iCub/contexts/cameraCalibration/customEyes.ini'; unable to remove target: Device or resource busy_.

We also removed the `tmp.txt` after the copy. 