### PR TITLE
Removed spaces from the icubEyesFile variable

### DIFF
--- a/cameraSupervision/app/run-all.sh
+++ b/cameraSupervision/app/run-all.sh
@@ -241,9 +241,10 @@ mono=$4
 robotName=$5
 
 icubEyesFile=$(yarp resource --context $calibContext --from $1 | awk -F'"' '{print $2}' )
-echo "Using file $icubEyesFile"
+icubEyesFileClean="$(echo -e "${icubEyesFile}" | tr -d '[:space:]')"
+echo "Using file $icubEyesFileClean"
 
-resourcePath=$(echo "$icubEyesFile" | sed 's|\(.*\)/.*|\1|')
+resourcePath=$(echo "$icubEyesFileClean" | sed 's|\(.*\)/.*|\1|')
 outputFile=$resourcePath/$2
 
 echo "stereoCalib writes the following file: $outputFile"


### PR DESCRIPTION
In this PR extra spaces have been removed from the `icubEyesFile` variable. 

These space were being propagated into `outputFile` and this was causing the "if statement" that checks the existence of `outputFile` to not work. 