### PR TITLE
Added "if statement" in order to remove outputCalib.ini after stereoCalib generates it

### DIFF
--- a/cameraSupervision/app/run-all.sh
+++ b/cameraSupervision/app/run-all.sh
@@ -317,6 +317,12 @@ rm tmp.txt
 
 sleep 3
 
+if test -f "$outputFile"; then
+    echo "$outputFile exists."
+    echo "Removing $outputFile."
+    rm $outputFile
+fi
+
 camCalib --name /camCalib/right --from $icubEyesFile --group CAMERA_CALIBRATION_RIGHT > /dev/null 2>&1 &
 camCalib --name /camCalib/left --from $icubEyesFile --group CAMERA_CALIBRATION_LEFT > /dev/null 2>&1
 


### PR DESCRIPTION
In this PR an `if statement` has been added in order to remove the `outputFile` as soon as it is generated from `stereoCalib`.

The `outputFile` has to be removed because when it is generated it has root permissions, but it is not safe to leave a file with root permission on the host.

Our deployment takes care of changing the permissions of new files generated by the deployment itself. However, the `outputFile` might already exist and in this case its permissions are not changed.
